### PR TITLE
fix android min sdk version because of rn .64 build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,7 @@ def DEFAULT_COMPILE_SDK_VERSION             = 27
 def DEFAULT_BUILD_TOOLS_VERSION             = "27.0.3"
 def DEFAULT_TARGET_SDK_VERSION              = 27
 def DEFAULT_ANDROID_SUPPORT_VERSION         = "27.1.0"
+def DEFAULT_ANDROID_MIN_SDK_VERSION         = 16
 
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -14,7 +15,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_ANDROID_MIN_SDK_VERSION
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Added minSdk check, if it exists in root project it will take from root, if not it will be 16 (16 is the lowest min sdk version of react native, so it wouldn't be a problem with the lowest react native version)